### PR TITLE
default to Mathlib v4

### DIFF
--- a/website/components/Layout.tsx
+++ b/website/components/Layout.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import Head from "next/head";
 import { FC, ReactNode } from "react";
 import HeaderNav from "../components/HeaderNav";
@@ -6,10 +7,9 @@ import { LeanVersion } from "../data/types";
 interface LayoutProps {
   children: ReactNode;
   version: LeanVersion;
-  banner?: ReactNode;
 }
 
-const Layout: FC<LayoutProps> = ({ children, version, banner }) => {
+const Layout: FC<LayoutProps> = ({ children, version }) => {
   return (
     <div>
       <Head>
@@ -22,7 +22,11 @@ const Layout: FC<LayoutProps> = ({ children, version, banner }) => {
       </Head>
 
       <HeaderNav version={version} />
-      {banner}
+      {version == "v3" && (
+        <div className="text-center p-3 bg-gray-200">
+          Mathlib v3 is deprecated. <Link href="/v4/">Go to Mathlib v4</Link>
+        </div>
+      )}
       <main className="container mt-4 mx-auto px-2">{children}</main>
     </div>
   );

--- a/website/next.config.js
+++ b/website/next.config.js
@@ -2,6 +2,45 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
-}
+  async redirects() {
+    return [
+      {
+        source: "/",
+        destination: "/v4",
+        permanent: false,
+      },
+      {
+        source: "/commit/:sha",
+        destination: "/v3/commit/:sha",
+        permanent: false,
+      },
+      {
+        source: "/def/:name",
+        destination: "/v3/def/:name",
+        permanent: false,
+      },
+      {
+        source: "/inductive/:name",
+        destination: "/v3/inductive/:name",
+        permanent: false,
+      },
+      {
+        source: "/structure/:name",
+        destination: "/v3/structure/:name",
+        permanent: false,
+      },
+      {
+        source: "/theorem/:name",
+        destination: "/v3/theorem/:name",
+        permanent: false,
+      },
+      {
+        source: "/changelog/:page",
+        destination: "/v3/changelog/:page",
+        permanent: false,
+      },
+    ];
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/website/pages/404.tsx
+++ b/website/pages/404.tsx
@@ -4,7 +4,7 @@ import Layout from "../components/Layout";
 
 const NotFound: NextPage = () => {
   return (
-    <Layout version="v3">
+    <Layout version="v4">
       <div className="text-center pt-10">
         <h1 className="text-6xl mt-20">404</h1>
         <p className="text-gray-600 mb-10">Page not found</p>

--- a/website/pages/v3/about.tsx
+++ b/website/pages/v3/about.tsx
@@ -1,5 +1,5 @@
 import type { NextPage } from "next";
-import Layout from "../components/Layout";
+import Layout from "../../components/Layout";
 
 const About: NextPage = () => {
   return (

--- a/website/pages/v3/changelog/[page].tsx
+++ b/website/pages/v3/changelog/[page].tsx
@@ -1,13 +1,13 @@
 import { GetStaticPaths, GetStaticProps, NextPage } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import Layout from "../../components/Layout";
-import Pagination from "../../components/Pagination";
-import Pill from "../../components/Pill";
-import { getCommitPages, getCommits } from "../../data/database";
-import { CommitData, ItemType } from "../../data/types";
-import formatTimestamp from "../../util/formatTimestamp";
-import summarizeHeadline from "../../util/summarizeHeadline";
+import Layout from "../../../components/Layout";
+import Pagination from "../../../components/Pagination";
+import Pill from "../../../components/Pill";
+import { getCommitPages, getCommits } from "../../../data/database";
+import { CommitData, ItemType } from "../../../data/types";
+import formatTimestamp from "../../../util/formatTimestamp";
+import summarizeHeadline from "../../../util/summarizeHeadline";
 
 const PER_PAGE = 50;
 
@@ -102,10 +102,10 @@ const Changelog: NextPage<ChangelogProps> = ({
         totalResults={totalResults}
         pageStartItemNum={pageStartItemNum}
         pageEndItemNum={pageEndItemNum}
-        onChangePage={(newPage) => router.push(`/changelog/${newPage}`)}
+        onChangePage={(newPage) => router.push(`/v3/changelog/${newPage}`)}
       />
       {commits.map((commit) => (
-        <Link href={`/commit/${commit.sha}`} key={commit.sha}>
+        <Link href={`/v3/commit/${commit.sha}`} key={commit.sha}>
           <a className="p-2 border border-gray-200 my-1 rounded-md hover:border-gray-400 transition text-gray-800 block">
             <div className="pb-1">
               <span className="text-blue-600">
@@ -154,7 +154,7 @@ const Changelog: NextPage<ChangelogProps> = ({
         totalResults={totalResults}
         pageStartItemNum={pageStartItemNum}
         pageEndItemNum={pageEndItemNum}
-        onChangePage={(newPage) => router.push(`/changelog/${newPage}`)}
+        onChangePage={(newPage) => router.push(`/v3/changelog/${newPage}`)}
       />
     </Layout>
   );

--- a/website/pages/v3/commit/[sha].tsx
+++ b/website/pages/v3/commit/[sha].tsx
@@ -1,11 +1,11 @@
 import { CodeIcon, MinusIcon, PlusIcon } from "@heroicons/react/solid";
 import { GetStaticPaths, GetStaticProps, NextPage } from "next";
 import Link from "next/link";
-import Layout from "../../components/Layout";
-import MathlibGithubMarkdown from "../../components/MathlibGithubMarkdown";
-import { getCommit } from "../../data/database";
-import { ChangeType, CommitData, DiffData } from "../../data/types";
-import formatTimestamp from "../../util/formatTimestamp";
+import Layout from "../../../components/Layout";
+import MathlibGithubMarkdown from "../../../components/MathlibGithubMarkdown";
+import { getCommit } from "../../../data/database";
+import { ChangeType, CommitData, DiffData } from "../../../data/types";
+import formatTimestamp from "../../../util/formatTimestamp";
 
 export const getStaticPaths: GetStaticPaths = () => ({
   paths: [],
@@ -119,7 +119,7 @@ const Commit: NextPage<CommitProps> = ({ commit }) => {
                         {getLabel(changeType)}
                       </span>{" "}
                       <span className="font-semibold">{itemType}</span>{" "}
-                      <Link href={`/${itemType}/${fullName}`}>
+                      <Link href={`/v3/${itemType}/${fullName}`}>
                         <a>{fullName}</a>
                       </Link>
                     </div>

--- a/website/pages/v3/def/[name].tsx
+++ b/website/pages/v3/def/[name].tsx
@@ -1,8 +1,8 @@
 import { GetStaticPaths, GetStaticProps, NextPage } from "next";
-import { ItemChangeHistory } from "../../components/ItemChangeHistory";
-import Layout from "../../components/Layout";
-import { getDef } from "../../data/database";
-import { ChangelogItemData } from "../../data/extractDataFromChangelog";
+import { ItemChangeHistory } from "../../../components/ItemChangeHistory";
+import Layout from "../../../components/Layout";
+import { getDef } from "../../../data/database";
+import { ChangelogItemData } from "../../../data/extractDataFromChangelog";
 
 export const getStaticPaths: GetStaticPaths = () => ({
   paths: [],

--- a/website/pages/v3/index.tsx
+++ b/website/pages/v3/index.tsx
@@ -4,9 +4,9 @@ import { useRouter } from "next/router";
 import classNames from "classnames";
 import Autosuggest from "react-autosuggest";
 import { useQuery } from "react-query";
-import Layout from "../components/Layout";
-import Spinner from "../components/Spinner";
-import { loadAndPopulateSearch, searchForQuery } from "../data/search";
+import Layout from "../../components/Layout";
+import Spinner from "../../components/Spinner";
+import { loadAndPopulateSearch, searchForQuery } from "../../data/search";
 import Link from "next/link";
 
 if (typeof window !== "undefined") {
@@ -25,15 +25,7 @@ const Home: NextPage = () => {
   });
 
   return (
-    <Layout
-      version="v3"
-      banner={
-        <div className="text-center p-3 bg-gray-200">
-          Experimental Mathlib v4 support is available.{" "}
-          <Link href="/v4">Try it out</Link>
-        </div>
-      }
-    >
+    <Layout version="v3">
       <div className="flex flex-wrap flex-col items-center text-center w-full">
         {isNavigating ? (
           <div className="w-[100px] pt-10">
@@ -57,7 +49,7 @@ const Home: NextPage = () => {
                 `${suggestion.type}:${suggestion.fullName}`
               }
               renderSuggestion={(suggestion) => (
-                <Link href={`/${suggestion.type}/${suggestion.fullName}`}>
+                <Link href={`/v3/${suggestion.type}/${suggestion.fullName}`}>
                   <a className="text-gray-800">
                     <span className="text-gray-400 min-w-[70px] inline-block text-right pr-1">
                       {suggestion.type}
@@ -71,7 +63,7 @@ const Home: NextPage = () => {
                 if (reason === "suggestion-selected") {
                   const type = value.replace(/:.*/, "");
                   const name = value.replace(/^[^:]*:/, "");
-                  router.push(`/${type}/${name}`);
+                  router.push(`/v3/${type}/${name}`);
                   setQuery("");
                   setIsNavigating(true);
                 }

--- a/website/pages/v3/inductive/[name].tsx
+++ b/website/pages/v3/inductive/[name].tsx
@@ -1,8 +1,8 @@
 import { GetStaticPaths, GetStaticProps, NextPage } from "next";
-import { ItemChangeHistory } from "../../components/ItemChangeHistory";
-import Layout from "../../components/Layout";
-import { getInductive } from "../../data/database";
-import { ChangelogItemData } from "../../data/extractDataFromChangelog";
+import { ItemChangeHistory } from "../../../components/ItemChangeHistory";
+import Layout from "../../../components/Layout";
+import { getInductive } from "../../../data/database";
+import { ChangelogItemData } from "../../../data/extractDataFromChangelog";
 
 export const getStaticPaths: GetStaticPaths = () => ({
   paths: [],

--- a/website/pages/v3/structure/[name].tsx
+++ b/website/pages/v3/structure/[name].tsx
@@ -1,8 +1,8 @@
 import { GetStaticPaths, GetStaticProps, NextPage } from "next";
-import { ItemChangeHistory } from "../../components/ItemChangeHistory";
-import Layout from "../../components/Layout";
-import { getStructure } from "../../data/database";
-import { ChangelogItemData } from "../../data/extractDataFromChangelog";
+import { ItemChangeHistory } from "../../../components/ItemChangeHistory";
+import Layout from "../../../components/Layout";
+import { getStructure } from "../../../data/database";
+import { ChangelogItemData } from "../../../data/extractDataFromChangelog";
 
 export const getStaticPaths: GetStaticPaths = () => ({
   paths: [],

--- a/website/pages/v3/theorem/[name].tsx
+++ b/website/pages/v3/theorem/[name].tsx
@@ -1,8 +1,8 @@
 import { GetStaticPaths, GetStaticProps, NextPage } from "next";
-import { ItemChangeHistory } from "../../components/ItemChangeHistory";
-import Layout from "../../components/Layout";
-import { getTheorem } from "../../data/database";
-import { ChangelogItemData } from "../../data/extractDataFromChangelog";
+import { ItemChangeHistory } from "../../../components/ItemChangeHistory";
+import Layout from "../../../components/Layout";
+import { getTheorem } from "../../../data/database";
+import { ChangelogItemData } from "../../../data/extractDataFromChangelog";
 
 export const getStaticPaths: GetStaticPaths = () => ({
   paths: [],

--- a/website/pages/v4/about.tsx
+++ b/website/pages/v4/about.tsx
@@ -1,4 +1,5 @@
 import type { NextPage } from "next";
+import Link from "next/link";
 import Layout from "../../components/Layout";
 
 const About: NextPage = () => {
@@ -10,7 +11,7 @@ const About: NextPage = () => {
           This project is an auto-updating list of changes from{" "}
           <a href="https://leanprover.github.io/">Lean</a>&apos;s{" "}
           <a
-            href="https://github.com/leanprover-community/mathlib"
+            href="https://github.com/leanprover-community/mathlib4"
             target="blank"
           >
             Mathlib library
@@ -34,6 +35,10 @@ const About: NextPage = () => {
             Github issue
           </a>
           .
+        </p>
+        <p className="mt-4 text-base leading-relaxed text-gray-800">
+          This version of the changelog supports Mathlib v4. You can find the{" "}
+          <Link href="/v3">Mathlib v3 changelog here</Link>.
         </p>
       </div>
     </Layout>

--- a/website/util/versionPrefix.ts
+++ b/website/util/versionPrefix.ts
@@ -1,5 +1,6 @@
 import { LeanVersion } from "../data/types";
 
-const versionPrefix = (version: LeanVersion) => (version === "v4" ? "/v4" : "");
+const versionPrefix = (version: LeanVersion) =>
+  version === "v4" ? "/v4" : "/v3";
 
 export default versionPrefix;


### PR DESCRIPTION
This PR defaults the changelog to v4 instead of v3. Previous changelog links should still work, and will redirect to the `/v3` prefixed version of the site. 